### PR TITLE
Fix warnings and privilege bug

### DIFF
--- a/src/binwalk/core/common.py
+++ b/src/binwalk/core/common.py
@@ -238,9 +238,17 @@ class MathExpression(object):
         return self._eval(ast.parse(expr).body[0].value)
 
     def _eval(self, node):
-        if isinstance(node, ast.Num):  # <number>
-            return node.n
-        elif isinstance(node, ast.operator):  # <operator>
+        # Handle numeric constants across Python versions without raising
+        # deprecation warnings. Newer Python versions use ast.Constant while
+        # older versions (<3.8) used ast.Num.
+        if sys.version_info >= (3, 8):
+            if isinstance(node, ast.Constant):
+                return node.value
+        else:
+            if isinstance(node, ast.Num):
+                return node.n
+
+        if isinstance(node, ast.operator):  # <operator>
             return self.OPERATORS[type(node.op)]
         elif isinstance(node, ast.UnaryOp):
             return self.OPERATORS[type(node.op)](0, self._eval(node.operand))

--- a/src/binwalk/core/magic.py
+++ b/src/binwalk/core/magic.py
@@ -428,7 +428,8 @@ class Magic(object):
         # Regex rule to find format strings
         self.fmtstr = re.compile("%[^%]")
         # Regex rule to find periods (see self._do_math)
-        self.period = re.compile("\.")
+        # Use a raw string to avoid invalid escape sequence warnings
+        self.period = re.compile(r"\.")
 
     def reset(self):
         self.display_once = set()

--- a/src/binwalk/modules/extractor.py
+++ b/src/binwalk/modules/extractor.py
@@ -966,11 +966,11 @@ class Extractor(Module):
             
             # Fork a child process
             child_pid = os.fork()
-            if child_pid is 0:
+            if child_pid == 0:
                 # Switch to the run-as user privileges, if one has been set
                 if self.runas_uid is not None and self.runas_gid is not None:
-                    os.setgid(self.runas_uid)
-                    os.setuid(self.runas_gid)
+                    os.setgid(self.runas_gid)
+                    os.setuid(self.runas_uid)
         else:
             # child_pid of None indicates that no os.fork() occured
             child_pid = None
@@ -981,7 +981,7 @@ class Extractor(Module):
             rval = subprocess.call(shlex.split(command), stdout=tmp, stderr=tmp)
 
         # A true child process should exit with the subprocess exit value
-        if child_pid is 0:
+        if child_pid == 0:
             sys.exit(rval)
         # If no os.fork() happened, just return the subprocess exit value
         elif child_pid is None:


### PR DESCRIPTION
## Summary
- fix invalid regex escape in `core.magic`
- correct privilege switching in `extractor`
- avoid ast deprecation warnings in `common`

## Testing
- `python -Wall -m py_compile $(git ls-files '*.py')`
- `pytest -q`

